### PR TITLE
Endpoint rebase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM alpine
+FROM golang:alpine AS builder
 
-LABEL org.opencontainers.image.source https://github.com/carldanley/zap2it-scraper
+WORKDIR /src
+COPY . .
+
+RUN go build -o zap2it-scraper main.go
+
+FROM alpine
 
 RUN apk upgrade --no-cache \
   && apk --no-cache add \
   tzdata zip ca-certificates
 
-WORKDIR /usr/share/zoneinfo
-RUN zip -r -0 /zoneinfo.zip .
-ENV ZONEINFO /zoneinfo.zip
+WORKDIR /zap2it-scraper
+COPY --from=builder /src/zap2it-scraper .
 
-WORKDIR /
-ADD zap2it-scraper /bin/
-
-ENTRYPOINT [ "/bin/zap2it-scraper" ]
+ENTRYPOINT [ "/zap2it-scraper/zap2it-scraper" ]

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ After finding a provider you're satisfied with, update the other environment var
 
 ## Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `ZAP2IT_USERNAME`  | Your [Zap2IT](https://tvlistings.zap2it.com/) Username |
-| `ZAP2IT_PASSWORD` | Your [Zap2IT](https://tvlistings.zap2it.com/) Password |
-| `ZAP2IT_SERVER_PORT` | The port this server should host the XMLTV guide on; `8080` is the default |
-| `ZAP2IT_COUNTRY_CODE` | The Zap2IT country code; `USA` is the default |
-| `ZAP2IT_LINEUP_ID` | The Zap2IT lineup ID; `DFT` is the default. See the `Fetching Providers` section for more information |
-| `ZAP2IT_HEADEND_ID` | The Zap2IT headend ID; `lineupId` is the default. See the `Fetching Providers` section for more information |
-| `ZAP2IT_DEVICE` | The Zap2IT device ID; `-` is the default. See the `Fetching Providers` section for more information |
-| `ZAP2IT_LANGUAGE` | The Zap2IT language your guide data should use; `en` is the default |
-| `ZAP2IT_DAYS_TO_FETCH` | The number of days of guide data to fetch from Zap2IT; `4` is the default |
-| `ZAP2IT_FETCH_PROVIDERS` | Whether or not to fetch the providers and output them as a table during startup; `false` is the default |
+| Variable | Description | |
+|----------|-------------| --- |
+| `ZAP2IT_USERNAME`  | Your [Zap2IT](https://tvlistings.zap2it.com/) Username | `Optional` |
+| `ZAP2IT_PASSWORD` | Your [Zap2IT](https://tvlistings.zap2it.com/) Password | `Optional` |
+| `ZAP2IT_SERVER_PORT` | The port this server should host the XMLTV guide on | `Required` `Default: 8080` |
+| `ZAP2IT_COUNTRY_CODE` | The Zap2IT country code | `Required` `Default: USA` |
+| `ZAP2IT_ZIP_CODE` | The Zap2IT zip code | `Required` |
+| `ZAP2IT_LINEUP_ID` | The Zap2IT lineup ID. See the `Fetching Providers` section for more information | `Required` `Default DFT` |
+| `ZAP2IT_HEADEND_ID` | The Zap2IT headend ID. See the `Fetching Providers` section for more information | `Required` `Default: lineupId` |
+| `ZAP2IT_DEVICE` | The Zap2IT device ID; `-` is the default. See the `Fetching Providers` section for more information | `Required` `Default: '-'` |
+| `ZAP2IT_LANGUAGE` | The Zap2IT language your guide data should use | `Required` `Default: en` |
+| `ZAP2IT_DAYS_TO_FETCH` | The number of days of guide data to fetch from Zap2IT. | `Required` `Default 4` |
+| `ZAP2IT_FETCH_PROVIDERS` | Whether or not to fetch the providers and output them as a table during startup. | `Required` `Default: false` |

--- a/README.md
+++ b/README.md
@@ -31,3 +31,48 @@ After finding a provider you're satisfied with, update the other environment var
 | `ZAP2IT_LANGUAGE` | The Zap2IT language your guide data should use | `Required` `Default: en` |
 | `ZAP2IT_DAYS_TO_FETCH` | The number of days of guide data to fetch from Zap2IT. | `Required` `Default 4` |
 | `ZAP2IT_FETCH_PROVIDERS` | Whether or not to fetch the providers and output them as a table during startup. | `Required` `Default: false` |
+
+## Docker build/run
+```
+docker build -t zap2it-scraper .
+
+docker run \
+  --name zap2it-scraper2 \
+  -e ZAP2IT_USERNAME="" \
+  -e ZAP2IT_PASSWORD="" \
+  -e ZAP2IT_SERVER_PORT="8080" \
+  -e ZAP2IT_COUNTRY_CODE="USA" \
+  -e ZAP2IT_ZIP_CODE="90210" \
+  -e ZAP2IT_LINEUP_ID="DFT" \
+  -e ZAP2IT_HEADEND_ID="lineupId" \
+  -e ZAP2IT_DEVICE="-" \
+  -e ZAP2IT_LANGUAGE="en" \
+  -e ZAP2IT_DAYS_TO_FETCH="7" \
+  -e ZAP2IT_FETCH_PROVIDERS="false" \
+  -p 8080:8080 \
+  --rm \
+  -d \
+  zap2it-scraper
+```
+
+## Docker Compose Example
+```
+services:
+  zap2it-scraper:
+    container_name: zap2it-scraper
+    build: ./src/zap2it-scraper
+    environment:
+      ZAP2IT_USERNAME: ""
+      ZAP2IT_PASSWORD: ""
+      ZAP2IT_SERVER_PORT: "8080"
+      ZAP2IT_COUNTRY_CODE: "USA"
+      ZAP2IT_ZIP_CODE: "90210"
+      ZAP2IT_LINEUP_ID: "DFT"
+      ZAP2IT_HEADEND_ID: "lineupId"
+      ZAP2IT_DEVICE: "-"
+      ZAP2IT_LANGUAGE: "en"
+      ZAP2IT_DAYS_TO_FETCH: "4"
+      ZAP2IT_FETCH_PROVIDERS: "false"
+    ports:
+      - 8080:8080
+```

--- a/pkg/xmltv/xmltv.go
+++ b/pkg/xmltv/xmltv.go
@@ -11,7 +11,7 @@ import (
 func CreateTVGuide(language string) *TVGuide {
 	return &TVGuide{
 		Language:          language,
-		SourceInfoURL:     "http://tvlistings.zap2it.com/",
+		SourceInfoURL:     "https://tvlistings.gracenote.com/",
 		SourceInfoName:    "zap2it",
 		GeneratorInfoName: "zap2it-scraper",
 		GeneratorInfoURL:  "https://github.com/carldanley/zap2it-scraper",

--- a/pkg/zap2it/guide.go
+++ b/pkg/zap2it/guide.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	URLGuideEndpoint = "https://tvlistings.zap2it.com/api/grid"
+	URLGuideEndpoint = "https://tvlistings.gracenote.com/api/grid"
 	URLIconPrefix    = "http://zap2it.tmsimg.com/assets"
 )
 
@@ -68,7 +68,7 @@ func (e *EventResponse) GetIconURL() string {
 }
 
 func (e *EventResponse) GetURL() string {
-	return fmt.Sprintf("https://tvlistings.zap2it.com/overview.html?programSeriesId=%s&tmsId=%s", e.SeriesID, e.Program.ID)
+	return fmt.Sprintf("https://tvlistings.gracenote.com/overview.html?programSeriesId=%s&tmsId=%s", e.SeriesID, e.Program.ID)
 }
 
 func GetGuideResponse(request GuideRequest) (GuideResponse, error) {

--- a/pkg/zap2it/providers.go
+++ b/pkg/zap2it/providers.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	URLListingProvidersEndpoint = "https://tvlistings.zap2it.com/gapzap_webapi/api/Providers/getPostalCodeProviders"
+	URLListingProvidersEndpoint = "https://tvlistings.gracenote.com/gapzap_webapi/api/Providers/getPostalCodeProviders"
 )
 
 type ListingProvidersResponse struct {

--- a/pkg/zap2it/token.go
+++ b/pkg/zap2it/token.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	URLTokenEndpoint = "https://tvlistings.zap2it.com/api/user/login"
+	URLTokenEndpoint = "https://tvlistings.gracenote.com/api/user/login"
 )
 
 type TokenResponse struct {


### PR DESCRIPTION
- Zap2It listing has been decommissioned. Replaced the URL endpoint to **tvlistings.gracenote.com** which functions the same as Zap2It.
- Updated README to include ZAP2IT_ZIP_CODE variable and some additional information.
- Updated the Dockerfile and added examples to the README file.

